### PR TITLE
update geyser-config in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -579,7 +579,9 @@ cat <<EOF>> ./$network/geyser-config.json
     ],
     "startup": false
   },
-  "instructionPrograms": []
+  "instructions": {
+    "programs": []
+  }
 }
 EOF
 ```


### PR DESCRIPTION
the geyser-config in the readme is outdated, the solana node would crash on plugin load with the unchanged version