### PR TITLE
Add dolphin stats to graphql server

### DIFF
--- a/indexer/mainnet/app/graphql.yaml
+++ b/indexer/mainnet/app/graphql.yaml
@@ -32,6 +32,8 @@ spec:
             name: meili-creds
         - secretRef:
             name: twitter-creds
+        - secretRef:
+            name: project-dolphin-creds
         env:
         - name: ASSET_PROXY_ENDPOINT
           value: "https://assets[n].holaplex.tools/"


### PR DESCRIPTION
### changes
- Include dolphin creds on graphql deployment to support proxy of timeseries.

https://github.com/holaplex/indexer/pull/856