### PR TITLE
Scale Geyser Consumers at 1.5k Queue Size

### DIFF
--- a/indexer/app/mq-consumer-autoscaling-trigger.yaml
+++ b/indexer/app/mq-consumer-autoscaling-trigger.yaml
@@ -29,7 +29,7 @@ spec:
       protocol: amqp
       queueName: mainnet.startup-all.accounts.indexer
       mode: QueueLength
-      value: "20000"
+      value: "1500"
       metricName: geyser-consumer-scaling
     authenticationRef:
       name: keda-trigger-auth-rabbitmq-conn
@@ -38,7 +38,7 @@ spec:
       protocol: amqp
       queueName: mainnet.accounts.indexer
       mode: QueueLength
-      value: "20000"
+      value: "1500"
       metricName: geyser-consumer-scaling
     authenticationRef:
       name: keda-trigger-auth-rabbitmq-conn


### PR DESCRIPTION
## Changes
- When the queue size of the account or startup-all queue is above 1.5k scale up pods up to 5